### PR TITLE
Fix lint issues and update types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "zod": "^3.24.2"
       },
       "devDependencies": {
+        "@types/dom-speech-recognition": "^0.0.6",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -3898,6 +3899,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
+    "node_modules/@types/dom-speech-recognition": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/dom-speech-recognition/-/dom-speech-recognition-0.0.6.tgz",
+      "integrity": "sha512-o7pAVq9UQPJL5RDjO1f/fcpfFHdgiMnR4PoIU2N/ZQrYOS3C5rzdOJMsrpqeBCbii2EE9mERXgqspQqPDdPahw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/handlebars": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@types/dom-speech-recognition": "^0.0.6",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/ai/flows/generate-image-for-sentence.ts
+++ b/src/ai/flows/generate-image-for-sentence.ts
@@ -28,14 +28,6 @@ const generateImageForSentenceFlowInternal = ai.defineFlow(
     name: 'generateImageForSentenceFlowInternal',
     inputSchema: GenerateImageInputSchema,
     outputSchema: GenerateImageOutputSchema,
-    config: {
-      safetySettings: [
-        { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_MEDIUM_AND_ABOVE' },
-        { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_MEDIUM_AND_ABOVE' },
-        { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_MEDIUM_AND_ABOVE' },
-        { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_MEDIUM_AND_ABOVE' },
-      ],
-    }
   },
   async (input) => {
     let promptText = `Create a child-friendly, simple, and colorful illustration for a children's learning app. This illustration should visually depict the scene or concept described by the following text, but it is CRITICAL that you DO NOT include ANY text, letters, words, numbers, or symbols in the image itself: "${input.sentences.join(' ')}"`;
@@ -51,10 +43,16 @@ const generateImageForSentenceFlowInternal = ai.defineFlow(
     try {
       console.log('[generateImageForSentenceFlowInternal] Attempting to generate image. Prompt text length:', promptText.length, 'Sentences:', input.sentences.join(' '));
       const { media } = await ai.generate({
-        model: 'googleai/gemini-2.0-flash-exp', 
+        model: 'googleai/gemini-2.0-flash-exp',
         prompt: promptText,
         config: {
           responseModalities: ['TEXT', 'IMAGE'],
+          safetySettings: [
+            { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_MEDIUM_AND_ABOVE' },
+            { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_MEDIUM_AND_ABOVE' },
+            { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_MEDIUM_AND_ABOVE' },
+            { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_MEDIUM_AND_ABOVE' },
+          ],
         },
       });
 

--- a/src/components/pin-dialog.tsx
+++ b/src/components/pin-dialog.tsx
@@ -65,7 +65,7 @@ export default function PinDialog({ mode, isOpen, setIsOpen, onSuccess, title, d
         return;
       }
       onSuccess(pin);
-      toast({ title: "PIN Setup Successful", description: "Your PIN has been set.", icon: <CheckCircle className="h-5 w-5 text-green-500" /> });
+      toast({ title: "PIN Setup Successful", description: "Your PIN has been set." });
     } else { // mode === 'enter'
       onSuccess(pin); // The calling component will verify the pin
     }


### PR DESCRIPTION
## Summary
- add `@types/dom-speech-recognition` for speech recognition typings
- fix `generate-image-for-sentence` flow options and add safety settings
- remove unsupported `icon` property from toast call

## Testing
- `npm run typecheck` *(fails: TS errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_68437405a0bc8331898a527a7d41dee3