### PR TITLE
Fix wording in blueprint

### DIFF
--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -6,7 +6,7 @@
 - Child Reference Update: Cloud Function triggers when a child profile is created to update the parent's profile with the new child's reference.
 - AI-Powered Lesson Generation: Generates a lesson using Gemini API based on structured JSON prompt incorporating child profile, recent mood, and lesson history.
 - Adaptive Lesson Display: Displays lessons in a format optimized for children, taking into account potential screen issues or preferred themes from their profiles.
-- Profile Persistence: Uses localStorage to store all the children profiles locally
+- Profile Persistence: Uses localStorage to store all child profiles locally
 
 ## Style Guidelines:
 


### PR DESCRIPTION
## Summary
- rephrase child profile storage line in docs/blueprint.md

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68434ad84ca483318e3d4305a7ae86a5